### PR TITLE
Extend Flash usage example

### DIFF
--- a/framework/tools/flash.md
+++ b/framework/tools/flash.md
@@ -21,13 +21,19 @@ $container[ WPEMERGE_SESSION_KEY ] = function() {
 
 A typical use case is to flash error messages inside a controller method in response to a user submitting a form:
 ```php
-// inside your controller method
-if ( $email_is_invalid ) {
-    // flash an error message
-    \App::flash()->add( 'errors', 'Please enter a valid email address.' );
-    // redirect the user back to the form
-    return \App::redirect()->back();
-}
+\App::route()->post()->url( '/contact-form' )
+    ->middleware( 'flash' )
+    ->handle( function ($request, $view) {
+        $is_valid_email = filter_var($request->body('email'), FILTER_VALIDATE_EMAIL);
+        if (!$is_valid_email) {
+            \App::flash()->add( 'errors', 'Please enter a valid email address.' );
+        }
+        
+        /* ... */ 
+        
+        // redirect the user back to the form
+        return \App::redirect()->back();
+    } );
 
 // inside your form view
 $errors = \App::flash()->get( 'errors' );


### PR DESCRIPTION
The [`Flash` usage example](https://github.com/htmlburger/wpemerge-docs/blob/590c216a55ec9fe809906280549753a3c7335ac9/framework/tools/flash.md) doesn't include the middleware, this PR extends it so it's more copy-paste-able. 